### PR TITLE
remove i18n

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -1,10 +1,6 @@
 const path = require('path');
 
 module.exports = {
-  i18n: {
-    defaultLocale: 'en',
-    locales: ['en', 'ja'],
-  },
   title: 'Azure Machine Learning',
   tagline: 'Open source cheat sheets for Azure ML',
   url: 'https://github.com/Azure/',
@@ -25,10 +21,6 @@ module.exports = {
       },
       items: [
         {to: '/docs/cheatsheets/python/v1/cheatsheet', label: 'Python SDK', position: 'left'},
-        {
-          type: 'localeDropdown',
-          position: 'left',
-        },
       ],
     },
     footer: {

--- a/website/i18n/jp/README.md
+++ b/website/i18n/jp/README.md
@@ -1,1 +1,0 @@
-This is a placeholder for translation files in Japanese. Please follow instructions: https://docusaurus.io/docs/i18n/tutorial


### PR DESCRIPTION
Search is broken with multilingual support. Temporarily remove localization placeholder until real contents are added.