### PR TITLE
Add 'recursive' parameter example for get_metrics()

### DIFF
--- a/website/docs/cheatsheets/python/v1/logging.md
+++ b/website/docs/cheatsheets/python/v1/logging.md
@@ -63,6 +63,10 @@ metrics = run.get_metrics()
 
 metrics.get('metric-name')
 # list of metrics in the order they were recorded
+
+metrics_including_child_runs = run.get_metrics(recursive=True)
+# set 'recursive' boolean parameter to True to also get
+# the metrics for child runs 
 ```
 
 To view all recorded values for a given metric `my-metric` in a


### PR DESCRIPTION
# PR into Azure/azureml-cheatsheets

## Checklist

I have:

- [x] read and followed the [contributing guidelines](https://azure.github.io/azureml-cheatsheets/docs/misc/contributing)

## Changes

- add example of using the `recursive` parameter for `get_metrics()`
